### PR TITLE
optimize apk steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,8 @@ RUN mkdir -p $PAYARA_PATH/deployments
 RUN adduser -D -h $PAYARA_PATH payara && echo payara:payara | chpasswd
 RUN chown -R payara:payara /opt
 
-RUN   apk update \                                                                                                                                                                                                                        
- &&   apk add ca-certificates wget \                                                                                                                                                                                                      
- &&   update-ca-certificates  
+RUN   apk --no-cache add ca-certificates wget \
+ &&   update-ca-certificates
 
 # Default payara ports to expose
 EXPOSE 4848 8009 8080 8181


### PR DESCRIPTION
https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache

> As of Alpine Linux 3.3 there exists a new --no-cache option for apk. It allows users to install packages with an index that is updated and used on-the-fly and not cached locally: This avoids the need to use --update and remove /var/cache/apk/* when done installing packages.