### PR TITLE
Fix of CMD and ENTRYPOINT to deploy an app from deploy dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ USER payara
 WORKDIR ${PAYARA_HOME}
 
 # Default command to run
-ENTRYPOINT java -jar payara-micro.jar
-CMD "--deploymentDir ${DEPLOY_DIR}"
+ENTRYPOINT ["java", "-jar", "payara-micro.jar"]
+CMD ["--deploymentDir", "/opt/payara/deployments"]
 
 # Download specific
 ENV PAYARA_VERSION 5.183


### PR DESCRIPTION
In my tests the current version of Dockerfile and its ENTRYPOINT and CMD failed the smoke tests. Payara Micro starts but ignores arguments in CMD and doesn't deploy the app.

This fixes it. A drawback is env var can't be used in CMD but it's not necessary.